### PR TITLE
- Modified: BaseTab.cs

### DIFF
--- a/Editor/WindowTab/ActorTab.cs
+++ b/Editor/WindowTab/ActorTab.cs
@@ -99,7 +99,6 @@ public class ActorTab : BaseTab
         ////////////////////////////////////////////////////////////////////////////////////////
         /////////////////////////////START REGION OF VALUE INIT/////////////////////////////////
         ////////////////////////////////////////////////////////////////////////////////////////
-        Debug.Log(traitIsOpen);
         float tabWidth = position.width * .85f;
         float tabHeight = position.height - 10f;
 
@@ -404,7 +403,7 @@ public class ActorTab : BaseTab
                     {
                         ChangeMaximum<ActorTraitsData>(++traitSize, traits, PathDatabase.ActorTraitExplicitDataPath);
                     }
-                    if (GUILayout.Button("Delete All Data", GUILayout.Width(traitsBox.width * .25f), GUILayout.Height(traitsBox.height * .065f)))
+                    if (GUILayout.Button("Delete All Data", GUILayout.Width(traitsBox.width * .3f), GUILayout.Height(traitsBox.height * .065f)))
                     {
                         if (EditorUtility.DisplayDialog("Delete All Trait Data", "Are you sure want to delete all Trait Data?", "Yes", "No"))
                         {

--- a/Editor/WindowTab/ActorTab.cs
+++ b/Editor/WindowTab/ActorTab.cs
@@ -48,7 +48,7 @@ public class ActorTab : BaseTab
     int index = 0;
     int traitIndex = 0;
     int indexTemp = -1;
-    int traitIndexTemp = -1;
+    int traitIndexTemp = 0;
     int typeIndex = 0;
 
     //Scroll position. Is this necessary?
@@ -89,17 +89,17 @@ public class ActorTab : BaseTab
     public void OnRender(Rect position)
     {
         #region A Bit Explanation About Local Tab
-    ///So there is 2 types of Tab,
-    ///One is in Database that not included here.
-    ///Second, there is 3 tab slicing in ActorTab itself.
-    ///So make sure you understand that tabbing in here does not
-    ///have any corelation with DatabaseMain.cs Tab system.
+        ///So there is 2 types of Tab,
+        ///One is in Database that not included here.
+        ///Second, there is 3 tab slicing in ActorTab itself.
+        ///So make sure you understand that tabbing in here does not
+        ///have any corelation with DatabaseMain.cs Tab system.
         #endregion
 
-    ////////////////////////////////////////////////////////////////////////////////////////
-    /////////////////////////////START REGION OF VALUE INIT/////////////////////////////////
-    ////////////////////////////////////////////////////////////////////////////////////////
-
+        ////////////////////////////////////////////////////////////////////////////////////////
+        /////////////////////////////START REGION OF VALUE INIT/////////////////////////////////
+        ////////////////////////////////////////////////////////////////////////////////////////
+        Debug.Log(traitIsOpen);
         float tabWidth = position.width * .85f;
         float tabHeight = position.height - 10f;
 
@@ -397,17 +397,12 @@ public class ActorTab : BaseTab
                         if (traitIndex != traitIndexTemp)
                         {
                             ActorTraitWindow.ShowWindow(traits, traitIndex, traitSize);
-                            traitIndexTemp = -1;
-                        }
-                        else
-                        {
                             traitIndexTemp = traitIndex;
                         }
                     }
                     if (traits[traitSize - 1].traitName != null && traitSize > 0)
                     {
-                        ChangeMaximum<ActorTraitsData>(traitSize + 1, traits, PathDatabase.ActorTraitExplicitDataPath);
-                        traitSize ++;
+                        ChangeMaximum<ActorTraitsData>(++traitSize, traits, PathDatabase.ActorTraitExplicitDataPath);
                     }
                     if (GUILayout.Button("Delete All Data", GUILayout.Width(traitsBox.width * .25f), GUILayout.Height(traitsBox.height * .065f)))
                     {

--- a/Editor/WindowTab/BaseTab.cs
+++ b/Editor/WindowTab/BaseTab.cs
@@ -42,7 +42,7 @@ public abstract class BaseTab
         }
         if (!AssetDatabase.IsValidFolder("Assets/Resources/Data/ActorData/TraitData"))
         {
-            AssetDatabase.CreateFolder("Assets/Resources/Data/TraitData", "TraitData");
+            AssetDatabase.CreateFolder("Assets/Resources/Data/ActorData", "TraitData");
         }
         if (!AssetDatabase.IsValidFolder("Assets/Resources/Image"))
         {


### PR DESCRIPTION
- Modified: BaseTab.cs, fixed an issue that makes TraitData won't show up on ActorTab
- Modified: ActorTab.cs, temporary fixing an issue that causes trait window always pops-up whenever GUI is changed, this is a 70% bug fixing, because we can't re-open the last trait index which was opened, but it won't always pops-up anymore, it will only popup whenever we clicked the different trait index, because it can't be popped-up on the same index, you have to create a SO on TraitData Folder to test how it runs if there's more than one SO exists in the folder

Link: https://trello.com/c/XZQg5rOU/122-bug-actortraitwindowcs-always-opens-when-gui-is-updated-without-being-clicked